### PR TITLE
Add metric templating

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,8 @@ edition = "2021"
 axum = { version="~0.5" }
 chrono = "~0.4"
 evalexpr = "7"
+new_string_template = "~1.3"
+regex = "~1.5"
 reqwest = { version = "~0.11", default-features = false, features = ["rustls-tls", "json"] }
 serde = { version = "~1.0", features = ["derive"] }
 serde_json = "~1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,5 +21,9 @@ tower-http = { version = "0.3.0", features = ["trace"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
+[dev-dependencies]
+mockito = "~0.31"
+tokio-test = "*"
+
 [target.'cfg(all(target_env = "musl", target_pointer_width = "64"))'.dependencies.jemallocator]
 version = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2021"
 axum = { version="~0.5" }
 chrono = "~0.4"
 evalexpr = "7"
+http = "~0.2"
 new_string_template = "~1.3"
 regex = "~1.5"
 reqwest = { version = "~0.11", default-features = false, features = ["rustls-tls", "json"] }
@@ -17,9 +18,10 @@ serde_json = "~1.0"
 serde_yaml = "~0.8"
 tokio = { version = "1", features = ["full"] }
 tower = { version = "~0.4" }
-tower-http = { version = "0.3.0", features = ["trace"] }
+tower-http = { version = "~0.3", features = ["trace", "request-id"] }
 tracing = "0.1"
-tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+tracing-subscriber = { version = "~0.3", features = ["env-filter"] }
+uuid = { version = "~1.1", features = ["v4", "fast-rng"] }
 
 [dev-dependencies]
 mockito = "~0.31"


### PR DESCRIPTION
Allow specifying metric template (query, operation, threshold) and
refering from metrics themselves. That helps keeping config file sane.
